### PR TITLE
Fix path text cutoff

### DIFF
--- a/app/src/main/res/layout/project_item.xml
+++ b/app/src/main/res/layout/project_item.xml
@@ -11,7 +11,7 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="50dp"
+        android:layout_height="wrap_content"
         android:padding="4dp">
 
         <ImageView


### PR DESCRIPTION
Changed the RelativeLayout height from fixed 50dp to wrap_content to ensure both name and path TextViews are fully visible. This prevents the path text from being truncated or hidden due to insufficient space within the card item.